### PR TITLE
Python3 compatibility

### DIFF
--- a/model.py
+++ b/model.py
@@ -73,7 +73,7 @@ class Model():
 
         ret = prime
         char = prime[-1]
-        for n in xrange(num):
+        for n in range(num):
             x = np.zeros((1, 1))
             x[0, 0] = vocab[char]
             feed = {self.input_data: x, self.initial_state:state}

--- a/sample.py
+++ b/sample.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
 import argparse
 import time
 import os
-import cPickle
+from six.moves import cPickle
 
 from utils import TextLoader
 from model import Model
@@ -21,9 +22,9 @@ def main():
     sample(args)
 
 def sample(args):
-    with open(os.path.join(args.save_dir, 'config.pkl')) as f:
+    with open(os.path.join(args.save_dir, 'config.pkl'), 'rb') as f:
         saved_args = cPickle.load(f)
-    with open(os.path.join(args.save_dir, 'chars_vocab.pkl')) as f:
+    with open(os.path.join(args.save_dir, 'chars_vocab.pkl'), 'rb') as f:
         chars, vocab = cPickle.load(f)
     model = Model(saved_args, True)
     with tf.Session() as sess:
@@ -32,7 +33,7 @@ def sample(args):
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)
-            print model.sample(sess, chars, vocab, args.n, args.prime)
+            print(model.sample(sess, chars, vocab, args.n, args.prime))
 
 if __name__ == '__main__':
     main()

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import os
 import collections
-import cPickle
+from six.moves import cPickle
 import numpy as np
 
 class TextLoader():
@@ -14,10 +14,10 @@ class TextLoader():
         tensor_file = os.path.join(data_dir, "data.npy")
 
         if not (os.path.exists(vocab_file) and os.path.exists(tensor_file)):
-            print "reading text file"
+            print("reading text file")
             self.preprocess(input_file, vocab_file, tensor_file)
         else:
-            print "loading preprocessed files"
+            print("loading preprocessed files")
             self.load_preprocessed(vocab_file, tensor_file)
         self.create_batches()
         self.reset_batch_pointer()
@@ -27,24 +27,26 @@ class TextLoader():
             data = f.read()
         counter = collections.Counter(data)
         count_pairs = sorted(counter.items(), key=lambda x: -x[1])
-        self.chars, _ = list(zip(*count_pairs))
+        self.chars, _ = zip(*count_pairs)
         self.vocab_size = len(self.chars)
         self.vocab = dict(zip(self.chars, range(len(self.chars))))
-        with open(vocab_file, 'w') as f:
+        with open(vocab_file, 'wb') as f:
             cPickle.dump(self.chars, f)
-        self.tensor = np.array(map(self.vocab.get, data))
+        self.tensor = np.array(list(map(self.vocab.get, data)))
         np.save(tensor_file, self.tensor)
 
     def load_preprocessed(self, vocab_file, tensor_file):
-        with open(vocab_file) as f:
+        with open(vocab_file, 'rb') as f:
             self.chars = cPickle.load(f)
         self.vocab_size = len(self.chars)
         self.vocab = dict(zip(self.chars, range(len(self.chars))))
         self.tensor = np.load(tensor_file)
-        self.num_batches = self.tensor.size / (self.batch_size * self.seq_length)
+        self.num_batches = int(self.tensor.size / (self.batch_size *
+                                                   self.seq_length))
 
     def create_batches(self):
-        self.num_batches = self.tensor.size / (self.batch_size * self.seq_length)
+        self.num_batches = int(self.tensor.size / (self.batch_size *
+                                                   self.seq_length))
         self.tensor = self.tensor[:self.num_batches * self.batch_size * self.seq_length]
         xdata = self.tensor
         ydata = np.copy(self.tensor)
@@ -61,4 +63,3 @@ class TextLoader():
 
     def reset_batch_pointer(self):
         self.pointer = 0
-


### PR DESCRIPTION
Basically just the output of `2to3` with a few tweaks:

- `2to3` is aggressive about converting `zip`s and other generators to `list`s, most of which is unnecessary
- Still use `cPickle` on Python2
- Properly open `.pkl` files in binary mode
- Handle integer division properly