### PR TITLE
suggested sampling type argument --sample

### DIFF
--- a/model.py
+++ b/model.py
@@ -58,7 +58,7 @@ class Model():
         optimizer = tf.train.AdamOptimizer(self.lr)
         self.train_op = optimizer.apply_gradients(zip(grads, tvars))
 
-    def sample(self, sess, chars, vocab, num=200, prime='The '):
+    def sample(self, sess, chars, vocab, num=200, prime='The ', sampling_type=1):
         state = self.cell.zero_state(1, tf.float32).eval()
         for char in prime[:-1]:
             x = np.zeros((1, 1))
@@ -79,8 +79,17 @@ class Model():
             feed = {self.input_data: x, self.initial_state:state}
             [probs, state] = sess.run([self.probs, self.final_state], feed)
             p = probs[0]
-            # sample = int(np.random.choice(len(p), p=p))
-            sample = weighted_pick(p)
+
+            if sampling_type == 0:
+                sample = np.argmax(p)
+            elif sampling_type == 2:
+                if char == ' ':
+                    sample = weighted_pick(p)
+                else:
+                    sample = np.argmax(p)
+            else: # sampling_type == 1 default:
+                sample = weighted_pick(p)
+
             pred = chars[sample]
             ret += pred
             char = pred

--- a/sample.py
+++ b/sample.py
@@ -18,6 +18,9 @@ def main():
                        help='number of characters to sample')
     parser.add_argument('--prime', type=str, default=' ',
                        help='prime text')
+    parser.add_argument('--sample', type=int, default=1,
+                       help='0 to use max at each timestep, 1 to sample at each timestep, 2 to sample on spaces')
+
     args = parser.parse_args()
     sample(args)
 
@@ -33,7 +36,7 @@ def sample(args):
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)
-            print(model.sample(sess, chars, vocab, args.n, args.prime))
+            print(model.sample(sess, chars, vocab, args.n, args.prime, args.sample))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Hello,

I have experimented a bit with several sampling methods and my proposal is to introduce the new command-line option similar to the original --sample option here:
https://github.com/karpathy/char-rnn/blob/master/sample.lua#L29

* Default value is 1: sample at each character which leads to frequent neologisms in generated text,
* Value 0 means always use the winner output which leads to loops in generated text since there is always the most frequent path (an attractor sequence),
* My best empirical experience is with the (new) value 2, i.e.: Randomly sample only on the first character of a word and keep winner characters inside a word, thus breaking attractor loops but avoid neologisms by likely preserving correct word spelling.

The motivation of this pull request is to make minimal changes and keep the current code as much as possible -- of course this proposal can be optimized more. 

Thank you for porting character language models to TensorFlow!
Pavel


