### PR TITLE
Better error message

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -47,6 +47,11 @@ class TextLoader():
     def create_batches(self):
         self.num_batches = int(self.tensor.size / (self.batch_size *
                                                    self.seq_length))
+
+        # When the data (tesor) is too small, let's give them a better error message
+        if self.num_batches==0:
+            assert False, "Not enough data. Make seq_length and batch_size small."
+
         self.tensor = self.tensor[:self.num_batches * self.batch_size * self.seq_length]
         xdata = self.tensor
         ydata = np.copy(self.tensor)


### PR DESCRIPTION
It is reported in #9 and #11. When we have a small data with large seq_length and batch_size small, num_batches becomes 0.

This prints a weird error message:
```
ydata[-1] = xdata[0]
IndexError: index 0 is out of bounds for axis 0 with size 0
```

I think it's safe to explain the error better.

