### PR TITLE
Implement temperature

### DIFF
--- a/model.py
+++ b/model.py
@@ -58,7 +58,7 @@ class Model():
         optimizer = tf.train.AdamOptimizer(self.lr)
         self.train_op = optimizer.apply_gradients(zip(grads, tvars))
 
-    def sample(self, sess, chars, vocab, num=200, prime='The ', sampling_type=1):
+    def sample(self, sess, chars, vocab, num=200, prime='The ', sampling_type=1, temperature=1.):
         state = self.cell.zero_state(1, tf.float32).eval()
         for char in prime[:-1]:
             x = np.zeros((1, 1))
@@ -77,6 +77,7 @@ class Model():
             x = np.zeros((1, 1))
             x[0, 0] = vocab[char]
             feed = {self.input_data: x, self.initial_state:state}
+            self.probs = tf.nn.softmax(tf.div(self.logits, temperature))
             [probs, state] = sess.run([self.probs, self.final_state], feed)
             p = probs[0]
 

--- a/sample.py
+++ b/sample.py
@@ -20,6 +20,8 @@ def main():
                        help='prime text')
     parser.add_argument('--sample', type=int, default=1,
                        help='0 to use max at each timestep, 1 to sample at each timestep, 2 to sample on spaces')
+    parser.add_argument('--temperature', type=float, default=1.,
+                       help='temperature for sampling, within the range of (0,1]')
 
     args = parser.parse_args()
     sample(args)
@@ -36,7 +38,7 @@ def sample(args):
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)
-            print(model.sample(sess, chars, vocab, args.n, args.prime, args.sample))
+            print(model.sample(sess, chars, vocab, args.n, args.prime, args.sample, args.temperature))
 
 if __name__ == '__main__':
     main()

--- a/train.py
+++ b/train.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument('--learning_rate', type=float, default=0.002,
                        help='learning rate')
     parser.add_argument('--decay_rate', type=float, default=0.97,
-                       help='decay rate for rmsprop')                       
+                       help='decay rate for rmsprop')
     parser.add_argument('--init_from', type=str, default=None,
                        help="""continue training from saved model at this path. Path must contain files saved by previous training process: 
                             'config.pkl'        : configuration;


### PR DESCRIPTION
Implement temperature with default value as 1. Following description is cited from [karpathy/char-rnn
 ](https://github.com/karpathy/char-rnn).
> Temperature. An important parameter you may want to play with is -temperature, which takes a number in range (0, 1] (0 not included), default = 1. The temperature is dividing the predicted log probabilities before the Softmax, so lower temperature will cause the model to make more likely, but also more boring and conservative predictions. Higher temperatures cause the model to take more chances and increase diversity of results, but at a cost of more mistakes.