### PR TITLE
Add encoding parameter to TextLoader, default to utf-8.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,13 +1,15 @@
+import codecs
 import os
 import collections
 from six.moves import cPickle
 import numpy as np
 
 class TextLoader():
-    def __init__(self, data_dir, batch_size, seq_length):
+    def __init__(self, data_dir, batch_size, seq_length, encoding='utf-8'):
         self.data_dir = data_dir
         self.batch_size = batch_size
         self.seq_length = seq_length
+        self.encoding = encoding
 
         input_file = os.path.join(data_dir, "input.txt")
         vocab_file = os.path.join(data_dir, "vocab.pkl")
@@ -23,7 +25,7 @@ class TextLoader():
         self.reset_batch_pointer()
 
     def preprocess(self, input_file, vocab_file, tensor_file):
-        with open(input_file, "r") as f:
+        with codecs.open(input_file, "r", encoding=self.encoding) as f:
             data = f.read()
         counter = collections.Counter(data)
         count_pairs = sorted(counter.items(), key=lambda x: -x[1])


### PR DESCRIPTION
Fix for https://github.com/sherjilozair/char-rnn-tensorflow/issues/38

Tested with Python 2.7, but not Python 3.x.

Additional encodings could be supported with an `--encoding` switch, but I think unicode should work for the vast majority of use-cases.