### PR TITLE
Make sample play nicer with unicode.

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -10,13 +10,15 @@ from six.moves import cPickle
 from utils import TextLoader
 from model import Model
 
+from six import text_type
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--save_dir', type=str, default='save',
                        help='model directory to store checkpointed models')
     parser.add_argument('-n', type=int, default=500,
                        help='number of characters to sample')
-    parser.add_argument('--prime', type=str, default=' ',
+    parser.add_argument('--prime', type=text_type, default=u' ',
                        help='prime text')
     parser.add_argument('--sample', type=int, default=1,
                        help='0 to use max at each timestep, 1 to sample at each timestep, 2 to sample on spaces')


### PR DESCRIPTION
Further fixes for https://github.com/sherjilozair/char-rnn-tensorflow/issues/38

Basically, sample was building up a `str` instead of a `unicode` on python2.7. I used `six.text_type` and defaulted prime to `u' '` to fix that.

One step closer to crazy emoji-based neural nets!