### PR TITLE
Open pickled files in binary mode

### DIFF
--- a/train.py
+++ b/train.py
@@ -62,14 +62,14 @@ def train(args):
         assert ckpt.model_checkpoint_path,"No model path found in checkpoint"
 
         # open old config and check if models are compatible
-        with open(os.path.join(args.init_from, 'config.pkl')) as f:
+        with open(os.path.join(args.init_from, 'config.pkl'), 'rb') as f:
             saved_model_args = cPickle.load(f)
         need_be_same=["model","rnn_size","num_layers","seq_length"]
         for checkme in need_be_same:
             assert vars(saved_model_args)[checkme]==vars(args)[checkme],"Command line argument and saved model disagree on '%s' "%checkme
         
         # open saved vocab/dict and check if vocabs/dicts are compatible
-        with open(os.path.join(args.init_from, 'chars_vocab.pkl')) as f:
+        with open(os.path.join(args.init_from, 'chars_vocab.pkl'), 'rb') as f:
             saved_chars, saved_vocab = cPickle.load(f)
         assert saved_chars==data_loader.chars, "Data and loaded model disagreee on character set!"
         assert saved_vocab==data_loader.vocab, "Data and loaded model disagreee on dictionary mappings!"


### PR DESCRIPTION
Originally parameters were saved in binary mode, this means that they must be opened in binary mode as well.

---

When attempting to continue training where left of you would receive this error

```
loading preprocessed files
Traceback (most recent call last):
  File "train.py", line 113, in <module>
    main()
  File "train.py", line 48, in main
    train(args)
  File "train.py", line 75, in train
    saved_chars, saved_vocab = cPickle.load(f)
  File "/usr/lib/python3.4/codecs.py", line 313, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid
```

[Source](http://stackoverflow.com/questions/32957708/python-pickle-error-unicodedecodeerror)

Everything looks good in the [sample.py](sample.py) though :smile: 
