### PR TITLE
Refactor to use state_is_tuple=True

### DIFF
--- a/model.py
+++ b/model.py
@@ -20,9 +20,9 @@ class Model():
         else:
             raise Exception("model type not supported: {}".format(args.model))
 
-        cell = cell_fn(args.rnn_size)
+        cell = cell_fn(args.rnn_size, state_is_tuple=True)
 
-        self.cell = cell = rnn_cell.MultiRNNCell([cell] * args.num_layers)
+        self.cell = cell = rnn_cell.MultiRNNCell([cell] * args.num_layers, state_is_tuple=True)
 
         self.input_data = tf.placeholder(tf.int32, [args.batch_size, args.seq_length])
         self.targets = tf.placeholder(tf.int32, [args.batch_size, args.seq_length])
@@ -59,7 +59,7 @@ class Model():
         self.train_op = optimizer.apply_gradients(zip(grads, tvars))
 
     def sample(self, sess, chars, vocab, num=200, prime='The ', sampling_type=1):
-        state = self.cell.zero_state(1, tf.float32).eval()
+        state = sess.run(self.cell.zero_state(1, tf.float32))
         for char in prime[:-1]:
             x = np.zeros((1, 1))
             x[0, 0] = vocab[char]

--- a/train.py
+++ b/train.py
@@ -90,11 +90,14 @@ def train(args):
         for e in range(args.num_epochs):
             sess.run(tf.assign(model.lr, args.learning_rate * (args.decay_rate ** e)))
             data_loader.reset_batch_pointer()
-            state = model.initial_state.eval()
+            state = sess.run(model.initial_state)
             for b in range(data_loader.num_batches):
                 start = time.time()
                 x, y = data_loader.next_batch()
-                feed = {model.input_data: x, model.targets: y, model.initial_state: state}
+                feed = {model.input_data: x, model.targets: y}
+                for i, (c, h) in enumerate(model.initial_state):
+                    feed[c] = state[i].c
+                    feed[h] = state[i].h
                 train_loss, state, _ = sess.run([model.cost, model.final_state, model.train_op], feed)
                 end = time.time()
                 print("{}/{} (epoch {}), train_loss = {:.3f}, time/batch = {:.3f}" \


### PR DESCRIPTION
In TensorFlow 0.11, the default behavior is for model states to be represented as tuples; forcing the old concatenated behavior using `state_is_tuple=False` prints a deprecation warning.

Adapting the code to work with `state_is_tuple=True` turned out to be easier than I expected, because the TensorFlow example script `ptb_word_lm.py` is structured very similarly to char-rnn-tensorflow and was refactored back in August to use tuple states. This pull request ports the changes from that example to char-rnn-tensorflow.