### PR TITLE
Create individual cell instances instead of copying the pointer to a unique cell

### DIFF
--- a/model.py
+++ b/model.py
@@ -20,9 +20,8 @@ class Model():
         else:
             raise Exception("model type not supported: {}".format(args.model))
 
-        cell = cell_fn(args.rnn_size, state_is_tuple=True)
-
-        self.cell = cell = rnn_cell.MultiRNNCell([cell] * args.num_layers, state_is_tuple=True)
+        self.cell = cell = rnn_cell.MultiRNNCell([cell_fn(args.rnn_size, state_is_tuple=True)
+                                                  for _ in range(args.num_layers)], state_is_tuple=True)
 
         self.input_data = tf.placeholder(tf.int32, [args.batch_size, args.seq_length])
         self.targets = tf.placeholder(tf.int32, [args.batch_size, args.seq_length])


### PR DESCRIPTION
I explain the proposed fix in details here: https://github.com/tensorflow/tensorflow/pull/5599
and you can compare output of `python train.py && python sample.py` here: https://gist.github.com/kevin-keraudren/cbb948f06ac817d8efa5ed110b980fa9

Without the fix, I attain a `train_loss` of `1.305` while in reaches `1.295` with the fix. More importantly, the output of the network sounds slightly more like Shakespeare.