### PR TITLE
Show defaults in --help

### DIFF
--- a/model.py
+++ b/model.py
@@ -4,6 +4,7 @@ from tensorflow.python.ops import seq2seq
 
 import numpy as np
 
+
 class Model():
     def __init__(self, args, infer=False):
         self.args = args
@@ -22,18 +23,25 @@ class Model():
 
         cell = cell_fn(args.rnn_size, state_is_tuple=True)
 
-        self.cell = cell = rnn_cell.MultiRNNCell([cell] * args.num_layers, state_is_tuple=True)
+        self.cell = cell = rnn_cell.MultiRNNCell(
+            [cell] * args.num_layers, state_is_tuple=True)
 
-        self.input_data = tf.placeholder(tf.int32, [args.batch_size, args.seq_length])
-        self.targets = tf.placeholder(tf.int32, [args.batch_size, args.seq_length])
+        self.input_data = tf.placeholder(
+            tf.int32, [args.batch_size, args.seq_length])
+        self.targets = tf.placeholder(
+            tf.int32, [args.batch_size, args.seq_length])
         self.initial_state = cell.zero_state(args.batch_size, tf.float32)
 
         with tf.variable_scope('rnnlm'):
-            softmax_w = tf.get_variable("softmax_w", [args.rnn_size, args.vocab_size])
+            softmax_w = tf.get_variable("softmax_w",
+                                        [args.rnn_size, args.vocab_size])
             softmax_b = tf.get_variable("softmax_b", [args.vocab_size])
             with tf.device("/cpu:0"):
-                embedding = tf.get_variable("embedding", [args.vocab_size, args.rnn_size])
-                inputs = tf.split(1, args.seq_length, tf.nn.embedding_lookup(embedding, self.input_data))
+                embedding = tf.get_variable("embedding",
+                                            [args.vocab_size, args.rnn_size])
+                inputs = tf.split(
+                    1, args.seq_length,
+                    tf.nn.embedding_lookup(embedding, self.input_data))
                 inputs = [tf.squeeze(input_, [1]) for input_ in inputs]
 
         def loop(prev, _):
@@ -41,29 +49,33 @@ class Model():
             prev_symbol = tf.stop_gradient(tf.argmax(prev, 1))
             return tf.nn.embedding_lookup(embedding, prev_symbol)
 
-        outputs, last_state = seq2seq.rnn_decoder(inputs, self.initial_state, cell, loop_function=loop if infer else None, scope='rnnlm')
+        outputs, last_state = seq2seq.rnn_decoder(
+            inputs, self.initial_state, cell,
+            loop_function=loop if infer else None, scope='rnnlm')
         output = tf.reshape(tf.concat(1, outputs), [-1, args.rnn_size])
         self.logits = tf.matmul(output, softmax_w) + softmax_b
         self.probs = tf.nn.softmax(self.logits)
-        loss = seq2seq.sequence_loss_by_example([self.logits],
-                [tf.reshape(self.targets, [-1])],
-                [tf.ones([args.batch_size * args.seq_length])],
-                args.vocab_size)
+        loss = seq2seq.sequence_loss_by_example(
+            [self.logits],
+            [tf.reshape(self.targets, [-1])],
+            [tf.ones([args.batch_size * args.seq_length])],
+            args.vocab_size)
         self.cost = tf.reduce_sum(loss) / args.batch_size / args.seq_length
         self.final_state = last_state
         self.lr = tf.Variable(0.0, trainable=False)
         tvars = tf.trainable_variables()
         grads, _ = tf.clip_by_global_norm(tf.gradients(self.cost, tvars),
-                args.grad_clip)
+                                          args.grad_clip)
         optimizer = tf.train.AdamOptimizer(self.lr)
         self.train_op = optimizer.apply_gradients(zip(grads, tvars))
 
-    def sample(self, sess, chars, vocab, num=200, prime='The ', sampling_type=1):
+    def sample(self, sess, chars, vocab, num=200, prime='The ',
+               sampling_type=1):
         state = sess.run(self.cell.zero_state(1, tf.float32))
         for char in prime[:-1]:
             x = np.zeros((1, 1))
             x[0, 0] = vocab[char]
-            feed = {self.input_data: x, self.initial_state:state}
+            feed = {self.input_data: x, self.initial_state: state}
             [state] = sess.run([self.final_state], feed)
 
         def weighted_pick(weights):
@@ -76,7 +88,7 @@ class Model():
         for n in range(num):
             x = np.zeros((1, 1))
             x[0, 0] = vocab[char]
-            feed = {self.input_data: x, self.initial_state:state}
+            feed = {self.input_data: x, self.initial_state: state}
             [probs, state] = sess.run([self.probs, self.final_state], feed)
             p = probs[0]
 
@@ -87,12 +99,10 @@ class Model():
                     sample = weighted_pick(p)
                 else:
                     sample = np.argmax(p)
-            else: # sampling_type == 1 default:
+            else:  # sampling_type == 1 default:
                 sample = weighted_pick(p)
 
             pred = chars[sample]
             ret += pred
             char = pred
         return ret
-
-

--- a/sample.py
+++ b/sample.py
@@ -1,13 +1,10 @@
 from __future__ import print_function
-import numpy as np
 import tensorflow as tf
 
 import argparse
-import time
 import os
 from six.moves import cPickle
 
-from utils import TextLoader
 from model import Model
 
 from six import text_type

--- a/sample.py
+++ b/sample.py
@@ -9,20 +9,23 @@ from model import Model
 
 from six import text_type
 
+
 def main():
     parser = argparse.ArgumentParser(
                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--save_dir', type=str, default='save',
-                       help='model directory to store checkpointed models')
+                        help='model directory to store checkpointed models')
     parser.add_argument('-n', type=int, default=500,
-                       help='number of characters to sample')
+                        help='number of characters to sample')
     parser.add_argument('--prime', type=text_type, default=u' ',
-                       help='prime text')
+                        help='prime text')
     parser.add_argument('--sample', type=int, default=1,
-                       help='0 to use max at each timestep, 1 to sample at each timestep, 2 to sample on spaces')
+                        help='0 to use max at each timestep, 1 to sample at '
+                             'each timestep, 2 to sample on spaces')
 
     args = parser.parse_args()
     sample(args)
+
 
 def sample(args):
     with open(os.path.join(args.save_dir, 'config.pkl'), 'rb') as f:
@@ -36,7 +39,9 @@ def sample(args):
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)
-            print(model.sample(sess, chars, vocab, args.n, args.prime, args.sample))
+            print(model.sample(sess, chars, vocab, args.n, args.prime,
+                               args.sample))
+
 
 if __name__ == '__main__':
     main()

--- a/sample.py
+++ b/sample.py
@@ -10,7 +10,8 @@ from model import Model
 from six import text_type
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+                       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--save_dir', type=str, default='save',
                        help='model directory to store checkpointed models')
     parser.add_argument('-n', type=int, default=500,

--- a/train.py
+++ b/train.py
@@ -10,7 +10,8 @@ from utils import TextLoader
 from model import Model
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+                       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--data_dir', type=str, default='data/tinyshakespeare',
                        help='data directory containing input.txt')
     parser.add_argument('--save_dir', type=str, default='save',

--- a/train.py
+++ b/train.py
@@ -9,43 +9,45 @@ from six.moves import cPickle
 from utils import TextLoader
 from model import Model
 
+
 def main():
     parser = argparse.ArgumentParser(
-                       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--data_dir', type=str, default='data/tinyshakespeare',
-                       help='data directory containing input.txt')
+                        help='data directory containing input.txt')
     parser.add_argument('--save_dir', type=str, default='save',
-                       help='directory to store checkpointed models')
+                        help='directory to store checkpointed models')
     parser.add_argument('--rnn_size', type=int, default=128,
-                       help='size of RNN hidden state')
+                        help='size of RNN hidden state')
     parser.add_argument('--num_layers', type=int, default=2,
-                       help='number of layers in the RNN')
+                        help='number of layers in the RNN')
     parser.add_argument('--model', type=str, default='lstm',
-                       help='rnn, gru, or lstm')
+                        help='rnn, gru, or lstm')
     parser.add_argument('--batch_size', type=int, default=50,
-                       help='minibatch size')
+                        help='minibatch size')
     parser.add_argument('--seq_length', type=int, default=50,
-                       help='RNN sequence length')
+                        help='RNN sequence length')
     parser.add_argument('--num_epochs', type=int, default=50,
-                       help='number of epochs')
+                        help='number of epochs')
     parser.add_argument('--save_every', type=int, default=1000,
-                       help='save frequency')
+                        help='save frequency')
     parser.add_argument('--grad_clip', type=float, default=5.,
-                       help='clip gradients at this value')
+                        help='clip gradients at this value')
     parser.add_argument('--learning_rate', type=float, default=0.002,
-                       help='learning rate')
+                        help='learning rate')
     parser.add_argument('--decay_rate', type=float, default=0.97,
-                       help='decay rate for rmsprop')
+                        help='decay rate for rmsprop')
     parser.add_argument('--init_from', type=str, default=None,
-                       help="""continue training from saved model at this path. Path must contain files saved by previous training process:
-                            'config.pkl'        : configuration;
-                            'chars_vocab.pkl'   : vocabulary definitions;
-                            'checkpoint'        : paths to model file(s) (created by tf).
-                                                  Note: this file contains absolute paths, be careful when moving files around;
-                            'model.ckpt-*'      : file(s) with model definition (created by tf)
+                        help="""continue training from saved model at this path. Path must contain files saved by previous training process:
+                             'config.pkl'        : configuration;
+                             'chars_vocab.pkl'   : vocabulary definitions;
+                             'checkpoint'        : paths to model file(s) (created by tf).
+                                                   Note: this file contains absolute paths, be careful when moving files around;
+                             'model.ckpt-*'      : file(s) with model definition (created by tf)
                         """)
     args = parser.parse_args()
     train(args)
+
 
 def train(args):
     data_loader = TextLoader(args.data_dir, args.batch_size, args.seq_length)
@@ -54,25 +56,25 @@ def train(args):
     # check compatibility if training is continued from previously saved model
     if args.init_from is not None:
         # check if all necessary files exist
-        assert os.path.isdir(args.init_from)," %s must be a a path" % args.init_from
-        assert os.path.isfile(os.path.join(args.init_from,"config.pkl")),"config.pkl file does not exist in path %s"%args.init_from
-        assert os.path.isfile(os.path.join(args.init_from,"chars_vocab.pkl")),"chars_vocab.pkl.pkl file does not exist in path %s" % args.init_from
+        assert os.path.isdir(args.init_from), " %s must be a a path" % args.init_from
+        assert os.path.isfile(os.path.join(args.init_from, "config.pkl")), "config.pkl file does not exist in path %s" % args.init_from
+        assert os.path.isfile(os.path.join(args.init_from, "chars_vocab.pkl")), "chars_vocab.pkl.pkl file does not exist in path %s" % args.init_from
         ckpt = tf.train.get_checkpoint_state(args.init_from)
-        assert ckpt,"No checkpoint found"
-        assert ckpt.model_checkpoint_path,"No model path found in checkpoint"
+        assert ckpt, "No checkpoint found"
+        assert ckpt.model_checkpoint_path, "No model path found in checkpoint"
 
         # open old config and check if models are compatible
         with open(os.path.join(args.init_from, 'config.pkl'), 'rb') as f:
             saved_model_args = cPickle.load(f)
-        need_be_same=["model","rnn_size","num_layers","seq_length"]
+        need_be_same = ["model", "rnn_size", "num_layers", "seq_length"]
         for checkme in need_be_same:
-            assert vars(saved_model_args)[checkme]==vars(args)[checkme],"Command line argument and saved model disagree on '%s' "%checkme
+            assert vars(saved_model_args)[checkme] == vars(args)[checkme], "Command line argument and saved model disagree on '%s' " % checkme
 
         # open saved vocab/dict and check if vocabs/dicts are compatible
         with open(os.path.join(args.init_from, 'chars_vocab.pkl'), 'rb') as f:
             saved_chars, saved_vocab = cPickle.load(f)
-        assert saved_chars==data_loader.chars, "Data and loaded model disagree on character set!"
-        assert saved_vocab==data_loader.vocab, "Data and loaded model disagree on dictionary mappings!"
+        assert saved_chars == data_loader.chars, "Data and loaded model disagree on character set!"
+        assert saved_vocab == data_loader.vocab, "Data and loaded model disagree on dictionary mappings!"
 
     with open(os.path.join(args.save_dir, 'config.pkl'), 'wb') as f:
         cPickle.dump(args, f)
@@ -88,7 +90,8 @@ def train(args):
         if args.init_from is not None:
             saver.restore(sess, ckpt.model_checkpoint_path)
         for e in range(args.num_epochs):
-            sess.run(tf.assign(model.lr, args.learning_rate * (args.decay_rate ** e)))
+            sess.run(tf.assign(model.lr,
+                               args.learning_rate * (args.decay_rate ** e)))
             data_loader.reset_batch_pointer()
             state = sess.run(model.initial_state)
             for b in range(data_loader.num_batches):
@@ -98,17 +101,22 @@ def train(args):
                 for i, (c, h) in enumerate(model.initial_state):
                     feed[c] = state[i].c
                     feed[h] = state[i].h
-                train_loss, state, _ = sess.run([model.cost, model.final_state, model.train_op], feed)
+                train_loss, state, _ = sess.run([model.cost, model.final_state,
+                                                 model.train_op], feed)
                 end = time.time()
-                print("{}/{} (epoch {}), train_loss = {:.3f}, time/batch = {:.3f}" \
-                    .format(e * data_loader.num_batches + b,
-                            args.num_epochs * data_loader.num_batches,
-                            e, train_loss, end - start))
+                print("{}/{} (epoch {}), train_loss = {:.3f}, time/batch = {:.3f}"
+                      .format(e * data_loader.num_batches + b,
+                              args.num_epochs * data_loader.num_batches,
+                              e, train_loss, end - start))
                 if (e * data_loader.num_batches + b) % args.save_every == 0\
-                    or (e==args.num_epochs-1 and b == data_loader.num_batches-1): # save for the last result
+                        or (e == args.num_epochs-1 and
+                            b == data_loader.num_batches-1):
+                    # save for the last result
                     checkpoint_path = os.path.join(args.save_dir, 'model.ckpt')
-                    saver.save(sess, checkpoint_path, global_step = e * data_loader.num_batches + b)
+                    saver.save(sess, checkpoint_path,
+                               global_step=e * data_loader.num_batches + b)
                     print("model saved to {}".format(checkpoint_path))
+
 
 if __name__ == '__main__':
     main()

--- a/train.py
+++ b/train.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import numpy as np
 import tensorflow as tf
 
 import argparse
@@ -35,9 +34,9 @@ def main():
     parser.add_argument('--learning_rate', type=float, default=0.002,
                        help='learning rate')
     parser.add_argument('--decay_rate', type=float, default=0.97,
-                       help='decay rate for rmsprop')                       
+                       help='decay rate for rmsprop')
     parser.add_argument('--init_from', type=str, default=None,
-                       help="""continue training from saved model at this path. Path must contain files saved by previous training process: 
+                       help="""continue training from saved model at this path. Path must contain files saved by previous training process:
                             'config.pkl'        : configuration;
                             'chars_vocab.pkl'   : vocabulary definitions;
                             'checkpoint'        : paths to model file(s) (created by tf).
@@ -50,10 +49,10 @@ def main():
 def train(args):
     data_loader = TextLoader(args.data_dir, args.batch_size, args.seq_length)
     args.vocab_size = data_loader.vocab_size
-    
+
     # check compatibility if training is continued from previously saved model
     if args.init_from is not None:
-        # check if all necessary files exist 
+        # check if all necessary files exist
         assert os.path.isdir(args.init_from)," %s must be a a path" % args.init_from
         assert os.path.isfile(os.path.join(args.init_from,"config.pkl")),"config.pkl file does not exist in path %s"%args.init_from
         assert os.path.isfile(os.path.join(args.init_from,"chars_vocab.pkl")),"chars_vocab.pkl.pkl file does not exist in path %s" % args.init_from
@@ -67,18 +66,18 @@ def train(args):
         need_be_same=["model","rnn_size","num_layers","seq_length"]
         for checkme in need_be_same:
             assert vars(saved_model_args)[checkme]==vars(args)[checkme],"Command line argument and saved model disagree on '%s' "%checkme
-        
+
         # open saved vocab/dict and check if vocabs/dicts are compatible
         with open(os.path.join(args.init_from, 'chars_vocab.pkl'), 'rb') as f:
             saved_chars, saved_vocab = cPickle.load(f)
         assert saved_chars==data_loader.chars, "Data and loaded model disagree on character set!"
         assert saved_vocab==data_loader.vocab, "Data and loaded model disagree on dictionary mappings!"
-        
+
     with open(os.path.join(args.save_dir, 'config.pkl'), 'wb') as f:
         cPickle.dump(args, f)
     with open(os.path.join(args.save_dir, 'chars_vocab.pkl'), 'wb') as f:
         cPickle.dump((data_loader.chars, data_loader.vocab), f)
-        
+
     model = Model(args)
 
     with tf.Session() as sess:

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ import collections
 from six.moves import cPickle
 import numpy as np
 
+
 class TextLoader():
     def __init__(self, data_dir, batch_size, seq_length, encoding='utf-8'):
         self.data_dir = data_dir
@@ -50,8 +51,9 @@ class TextLoader():
         self.num_batches = int(self.tensor.size / (self.batch_size *
                                                    self.seq_length))
 
-        # When the data (tensor) is too small, let's give them a better error message
-        if self.num_batches==0:
+        # When the data (tensor) is too small,
+        # let's give them a better error message
+        if self.num_batches == 0:
             assert False, "Not enough data. Make seq_length and batch_size small."
 
         self.tensor = self.tensor[:self.num_batches * self.batch_size * self.seq_length]
@@ -59,9 +61,10 @@ class TextLoader():
         ydata = np.copy(self.tensor)
         ydata[:-1] = xdata[1:]
         ydata[-1] = xdata[0]
-        self.x_batches = np.split(xdata.reshape(self.batch_size, -1), self.num_batches, 1)
-        self.y_batches = np.split(ydata.reshape(self.batch_size, -1), self.num_batches, 1)
-
+        self.x_batches = np.split(xdata.reshape(self.batch_size, -1),
+                                  self.num_batches, 1)
+        self.y_batches = np.split(ydata.reshape(self.batch_size, -1),
+                                  self.num_batches, 1)
 
     def next_batch(self):
         x, y = self.x_batches[self.pointer], self.y_batches[self.pointer]


### PR DESCRIPTION
Also remove unused imports (found with `pyflakes .`) and pep8 updates.

Before:
```
$ python train.py --help && python sample.py --help
usage: train.py [-h] [--data_dir DATA_DIR] [--save_dir SAVE_DIR]
                [--rnn_size RNN_SIZE] [--num_layers NUM_LAYERS]
                [--model MODEL] [--batch_size BATCH_SIZE]
                [--seq_length SEQ_LENGTH] [--num_epochs NUM_EPOCHS]
                [--save_every SAVE_EVERY] [--grad_clip GRAD_CLIP]
                [--learning_rate LEARNING_RATE] [--decay_rate DECAY_RATE]
                [--init_from INIT_FROM]

optional arguments:
  -h, --help            show this help message and exit
  --data_dir DATA_DIR   data directory containing input.txt
  --save_dir SAVE_DIR   directory to store checkpointed models
  --rnn_size RNN_SIZE   size of RNN hidden state
  --num_layers NUM_LAYERS
                        number of layers in the RNN
  --model MODEL         rnn, gru, or lstm
  --batch_size BATCH_SIZE
                        minibatch size
  --seq_length SEQ_LENGTH
                        RNN sequence length
  --num_epochs NUM_EPOCHS
                        number of epochs
  --save_every SAVE_EVERY
                        save frequency
  --grad_clip GRAD_CLIP
                        clip gradients at this value
  --learning_rate LEARNING_RATE
                        learning rate
  --decay_rate DECAY_RATE
                        decay rate for rmsprop
  --init_from INIT_FROM
                        continue training from saved model at this path. Path
                        must contain files saved by previous training process:
                        'config.pkl' : configuration; 'chars_vocab.pkl' :
                        vocabulary definitions; 'checkpoint' : paths to model
                        file(s) (created by tf). Note: this file contains
                        absolute paths, be careful when moving files around;
                        'model.ckpt-*' : file(s) with model definition
                        (created by tf)
usage: sample.py [-h] [--save_dir SAVE_DIR] [-n N] [--prime PRIME]
                 [--sample SAMPLE]

optional arguments:
  -h, --help           show this help message and exit
  --save_dir SAVE_DIR  model directory to store checkpointed models
  -n N                 number of characters to sample
  --prime PRIME        prime text
  --sample SAMPLE      0 to use max at each timestep, 1 to sample at each
                       timestep, 2 to sample on spaces
```

After:
```
$ python train.py --help && python sample.py --help
usage: train.py [-h] [--data_dir DATA_DIR] [--save_dir SAVE_DIR]
                [--rnn_size RNN_SIZE] [--num_layers NUM_LAYERS]
                [--model MODEL] [--batch_size BATCH_SIZE]
                [--seq_length SEQ_LENGTH] [--num_epochs NUM_EPOCHS]
                [--save_every SAVE_EVERY] [--grad_clip GRAD_CLIP]
                [--learning_rate LEARNING_RATE] [--decay_rate DECAY_RATE]
                [--init_from INIT_FROM]

optional arguments:
  -h, --help            show this help message and exit
  --data_dir DATA_DIR   data directory containing input.txt (default:
                        data/tinyshakespeare)
  --save_dir SAVE_DIR   directory to store checkpointed models (default: save)
  --rnn_size RNN_SIZE   size of RNN hidden state (default: 128)
  --num_layers NUM_LAYERS
                        number of layers in the RNN (default: 2)
  --model MODEL         rnn, gru, or lstm (default: lstm)
  --batch_size BATCH_SIZE
                        minibatch size (default: 50)
  --seq_length SEQ_LENGTH
                        RNN sequence length (default: 50)
  --num_epochs NUM_EPOCHS
                        number of epochs (default: 50)
  --save_every SAVE_EVERY
                        save frequency (default: 1000)
  --grad_clip GRAD_CLIP
                        clip gradients at this value (default: 5.0)
  --learning_rate LEARNING_RATE
                        learning rate (default: 0.002)
  --decay_rate DECAY_RATE
                        decay rate for rmsprop (default: 0.97)
  --init_from INIT_FROM
                        continue training from saved model at this path. Path
                        must contain files saved by previous training process:
                        'config.pkl' : configuration; 'chars_vocab.pkl' :
                        vocabulary definitions; 'checkpoint' : paths to model
                        file(s) (created by tf). Note: this file contains
                        absolute paths, be careful when moving files around;
                        'model.ckpt-*' : file(s) with model definition
                        (created by tf) (default: None)
usage: sample.py [-h] [--save_dir SAVE_DIR] [-n N] [--prime PRIME]
                 [--sample SAMPLE]

optional arguments:
  -h, --help           show this help message and exit
  --save_dir SAVE_DIR  model directory to store checkpointed models (default:
                       save)
  -n N                 number of characters to sample (default: 500)
  --prime PRIME        prime text (default: )
  --sample SAMPLE      0 to use max at each timestep, 1 to sample at each
                       timestep, 2 to sample on spaces (default: 1)
```