### PR TITLE
Simple tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+
+python:
+ - pypy3
+ - pypy
+ - 2.7
+ - 2.6
+ - 3.6
+ - 3.5
+ - 3.4
+ - 3.3
+ - 3.2
+
+# Use container-based infrastructure
+sudo: false
+
+install:
+ - pip install pyflakes
+
+script:
+ - pyflakes .
+
+after_script:
+ - pip install pep8
+ - pep8 --statistics --count .

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
  - 3.5
  - 3.4
  - 3.3
- - 3.2
 
 # Use container-based infrastructure
 sudo: false

--- a/sample.py
+++ b/sample.py
@@ -1,13 +1,10 @@
 from __future__ import print_function
-import numpy as np
 import tensorflow as tf
 
 import argparse
-import time
 import os
 from six.moves import cPickle
 
-from utils import TextLoader
 from model import Model
 
 from six import text_type

--- a/train.py
+++ b/train.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import numpy as np
 import tensorflow as tf
 
 import argparse
@@ -35,9 +34,9 @@ def main():
     parser.add_argument('--learning_rate', type=float, default=0.002,
                        help='learning rate')
     parser.add_argument('--decay_rate', type=float, default=0.97,
-                       help='decay rate for rmsprop')                       
+                       help='decay rate for rmsprop')
     parser.add_argument('--init_from', type=str, default=None,
-                       help="""continue training from saved model at this path. Path must contain files saved by previous training process: 
+                       help="""continue training from saved model at this path. Path must contain files saved by previous training process:
                             'config.pkl'        : configuration;
                             'chars_vocab.pkl'   : vocabulary definitions;
                             'checkpoint'        : paths to model file(s) (created by tf).
@@ -50,10 +49,10 @@ def main():
 def train(args):
     data_loader = TextLoader(args.data_dir, args.batch_size, args.seq_length)
     args.vocab_size = data_loader.vocab_size
-    
+
     # check compatibility if training is continued from previously saved model
     if args.init_from is not None:
-        # check if all necessary files exist 
+        # check if all necessary files exist
         assert os.path.isdir(args.init_from)," %s must be a a path" % args.init_from
         assert os.path.isfile(os.path.join(args.init_from,"config.pkl")),"config.pkl file does not exist in path %s"%args.init_from
         assert os.path.isfile(os.path.join(args.init_from,"chars_vocab.pkl")),"chars_vocab.pkl.pkl file does not exist in path %s" % args.init_from
@@ -67,18 +66,18 @@ def train(args):
         need_be_same=["model","rnn_size","num_layers","seq_length"]
         for checkme in need_be_same:
             assert vars(saved_model_args)[checkme]==vars(args)[checkme],"Command line argument and saved model disagree on '%s' "%checkme
-        
+
         # open saved vocab/dict and check if vocabs/dicts are compatible
         with open(os.path.join(args.init_from, 'chars_vocab.pkl'), 'rb') as f:
             saved_chars, saved_vocab = cPickle.load(f)
         assert saved_chars==data_loader.chars, "Data and loaded model disagree on character set!"
         assert saved_vocab==data_loader.vocab, "Data and loaded model disagree on dictionary mappings!"
-        
+
     with open(os.path.join(args.save_dir, 'config.pkl'), 'wb') as f:
         cPickle.dump(args, f)
     with open(os.path.join(args.save_dir, 'chars_vocab.pkl'), 'wb') as f:
         cPickle.dump((data_loader.chars, data_loader.vocab), f)
-        
+
     model = Model(args)
 
     with tf.Session() as sess:


### PR DESCRIPTION
Runs `pyflakes` to check for some possible errors on Python 2 and Python 3.

Also runs `pep8` on the source, but for information only and won't fail the build.

Unused imports have been removed so `pyflakes` passes.

Please enable this repo at https://travis-ci.org/profile, it's free for open source.

If unit or integration tests come along in the future, they can be run on Travis as well.
