### PR TITLE
Make save_dir if doesn't exist

### DIFF
--- a/train.py
+++ b/train.py
@@ -35,9 +35,9 @@ def main():
     parser.add_argument('--learning_rate', type=float, default=0.002,
                        help='learning rate')
     parser.add_argument('--decay_rate', type=float, default=0.97,
-                       help='decay rate for rmsprop')                       
+                       help='decay rate for rmsprop')
     parser.add_argument('--init_from', type=str, default=None,
-                       help="""continue training from saved model at this path. Path must contain files saved by previous training process: 
+                       help="""continue training from saved model at this path. Path must contain files saved by previous training process:
                             'config.pkl'        : configuration;
                             'chars_vocab.pkl'   : vocabulary definitions;
                             'checkpoint'        : paths to model file(s) (created by tf).
@@ -50,10 +50,10 @@ def main():
 def train(args):
     data_loader = TextLoader(args.data_dir, args.batch_size, args.seq_length)
     args.vocab_size = data_loader.vocab_size
-    
+
     # check compatibility if training is continued from previously saved model
     if args.init_from is not None:
-        # check if all necessary files exist 
+        # check if all necessary files exist
         assert os.path.isdir(args.init_from)," %s must be a a path" % args.init_from
         assert os.path.isfile(os.path.join(args.init_from,"config.pkl")),"config.pkl file does not exist in path %s"%args.init_from
         assert os.path.isfile(os.path.join(args.init_from,"chars_vocab.pkl")),"chars_vocab.pkl.pkl file does not exist in path %s" % args.init_from
@@ -67,18 +67,20 @@ def train(args):
         need_be_same=["model","rnn_size","num_layers","seq_length"]
         for checkme in need_be_same:
             assert vars(saved_model_args)[checkme]==vars(args)[checkme],"Command line argument and saved model disagree on '%s' "%checkme
-        
+
         # open saved vocab/dict and check if vocabs/dicts are compatible
         with open(os.path.join(args.init_from, 'chars_vocab.pkl'), 'rb') as f:
             saved_chars, saved_vocab = cPickle.load(f)
         assert saved_chars==data_loader.chars, "Data and loaded model disagree on character set!"
         assert saved_vocab==data_loader.vocab, "Data and loaded model disagree on dictionary mappings!"
-        
+
+    if not os.path.isdir(args.save_dir):
+        os.makedirs(args.save_dir)
     with open(os.path.join(args.save_dir, 'config.pkl'), 'wb') as f:
         cPickle.dump(args, f)
     with open(os.path.join(args.save_dir, 'chars_vocab.pkl'), 'wb') as f:
         cPickle.dump((data_loader.chars, data_loader.vocab), f)
-        
+
     model = Model(args)
 
     with tf.Session() as sess:


### PR DESCRIPTION
Before:
```
$ python train.py --save_dir save/some_sub_dir/another_sub_dir
loading preprocessed files
Traceback (most recent call last):
  File "train.py", line 116, in <module>
    main()
  File "train.py", line 48, in main
    train(args)
  File "train.py", line 79, in train
    with open(os.path.join(args.save_dir, 'config.pkl'), 'wb') as f:
IOError: [Errno 2] No such file or directory: 'save/some_sub_dir/another_sub_dir/config.pkl'
```

After:
```
$ python train.py --save_dir save/some_sub_dir/another_sub_dir
loading preprocessed files
0/22300 (epoch 0), train_loss = 4.828, time/batch = 3.988
...
```