### PR TITLE
Replace deprecated Tensorflow functions

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -33,8 +33,8 @@ def sample(args):
         chars, vocab = cPickle.load(f)
     model = Model(saved_args, True)
     with tf.Session() as sess:
-        tf.initialize_all_variables().run()
-        saver = tf.train.Saver(tf.all_variables())
+        tf.global_variables_initializer().run()
+        saver = tf.train.Saver(tf.global_variables())
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)


### PR DESCRIPTION
Tensorflow 0.12.1

Before:
```
$ python sample.py 
WARNING:tensorflow:From sample.py:36 in sample.: initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead.
WARNING:tensorflow:From sample.py:37 in sample.: all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Please use tf.global_variables instead.
 is ending brecatauted night.

POLION:
Now, if lays so forgion wor thou Edward;
We follow to't retrebthen with me, I would grant
Mis reby.
```

After:
```
$ python sample.py
 shen the had oul wach:
Marets an then us in this angrerine:
And Gugle if thee wive
To proolese as weshen his herpe?
```
