### PR TITLE
Encode output

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -38,7 +38,8 @@ def sample(args):
         ckpt = tf.train.get_checkpoint_state(args.save_dir)
         if ckpt and ckpt.model_checkpoint_path:
             saver.restore(sess, ckpt.model_checkpoint_path)
-            print(model.sample(sess, chars, vocab, args.n, args.prime, args.sample))
+            print(model.sample(sess, chars, vocab, args.n, args.prime,
+                               args.sample).encode('utf-8'))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When the output contains Unicode like ä and ö, and redirecting output like `python sample.py > output.txt`

```
Traceback (most recent call last):
  File "sample.py", line 44, in <module>
    main()
  File "sample.py", line 27, in main
    sample(args)
  File "sample.py", line 41, in sample
    print(model.sample(sess, chars, vocab, args.n, args.prime, args.sample))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 31: ordinal not in range(128)
```

So encode the output as UTF-8 instead.