### PR TITLE
ENH: the allocation to CPU is unneeded

### DIFF
--- a/model.py
+++ b/model.py
@@ -31,10 +31,9 @@ class Model():
         with tf.variable_scope('rnnlm'):
             softmax_w = tf.get_variable("softmax_w", [args.rnn_size, args.vocab_size])
             softmax_b = tf.get_variable("softmax_b", [args.vocab_size])
-            with tf.device("/cpu:0"):
-                embedding = tf.get_variable("embedding", [args.vocab_size, args.rnn_size])
-                inputs = tf.split(1, args.seq_length, tf.nn.embedding_lookup(embedding, self.input_data))
-                inputs = [tf.squeeze(input_, [1]) for input_ in inputs]
+            embedding = tf.get_variable("embedding", [args.vocab_size, args.rnn_size])
+            inputs = tf.split(1, args.seq_length, tf.nn.embedding_lookup(embedding, self.input_data))
+            inputs = [tf.squeeze(input_, [1]) for input_ in inputs]
 
         def loop(prev, _):
             prev = tf.matmul(prev, softmax_w) + softmax_b


### PR DESCRIPTION
TF could place operations to appropriate devices without setting this explicitly, the embedding op is implemented on GPU since 0.9, so the declaration could be safely omitted. Also the placement on GPU gives performance boost about 5-10% in my experiments