### PR TITLE
Improve readme and command line help

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Inspired from Andrej Karpathy's [char-rnn](https://github.com/karpathy/char-rnn)
 To train with default parameters on the tinyshakespeare corpus, run `python train.py`. To access all the parameters use `python train.py --help`.
 
 To sample from a checkpointed model, `python sample.py`.
+Sampling while the learning is still in progress (to check last checkpoint) works only in CPU or using another GPU.
+To force CPU mode, use `export CUDA_VISIBLE_DEVICES=""` and `unset CUDA_VISIBLE_DEVICES` afterward
+(resp. `set CUDA_VISIBLE_DEVICES=""` and `set CUDA_VISIBLE_DEVICES=` on Windows).
+
+To continue training after interruption or to run on more epochs, `python train.py --init_from=save`
 
 ## Datasets
 You can use any plain text file as input. For example you could download [The complete Sherlock Holmes](https://sherlock-holm.es/ascii/) as such:
@@ -30,7 +35,22 @@ mv cnus.txt input.txt
 
 Then start train from the top level directory using `python train.py --data_dir=./data/sherlock/`
 
-A quick tip to concatenate many small disparate `.txt` files into one large training file: `ls *.txt | xargs -L 1 cat >> input.txt`
+A quick tip to concatenate many small disparate `.txt` files into one large training file: `ls *.txt | xargs -L 1 cat >> input.txt`.
+
+## Tuning
+
+Tuning your models is kind of a "dark art" at this point. In general:
+
+1. Start with as much clean input.txt as possible e.g. 50MiB
+2. Start by establishing a baseline using the default settings.
+3. Use tensorboard to compare all of your runs visually to aid in experimenting.
+4. Tweak --rnn_size up somewhat from 128 if you have a lot of input data.
+5. Tweak --num_layers from 2 to 3 but no higher unless you have experience.
+6. Tweak --seq_length up from 50 based on the length of a valid input string
+   (e.g. names are <= 12 characters, sentences may be up to 64 characters, etc).
+   An lstm cell will "remember" for durations longer than this sequence, but the effect falls off for longer character distances.
+7. Finally once you've done all that, only then would I suggest adding some dropout.
+   Start with --output_keep_prob 0.8 and maybe end up with both --input_keep_prob 0.8 --output_keep_prob 0.5 only after exhausting all the above values.
 
 ## Tensorboard
 To visualize training progress, model graphs, and internal state histograms:  fire up Tensorboard and point it at your `log_dir`.  E.g.:

--- a/train.py
+++ b/train.py
@@ -13,26 +13,41 @@ from model import Model
 def main():
     parser = argparse.ArgumentParser(
                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    # Data and model checkpoints directories
     parser.add_argument('--data_dir', type=str, default='data/tinyshakespeare',
-                        help='data directory containing input.txt')
+                        help='data directory containing input.txt with training examples')
     parser.add_argument('--save_dir', type=str, default='save',
                         help='directory to store checkpointed models')
     parser.add_argument('--log_dir', type=str, default='logs',
                         help='directory to store tensorboard logs')
+    parser.add_argument('--save_every', type=int, default=1000,
+                        help='Save frequency. Number of passes between checkpoints of the model.')
+    parser.add_argument('--init_from', type=str, default=None,
+                        help="""continue training from saved model at this path (usually "save").
+                            Path must contain files saved by previous training process:
+                            'config.pkl'        : configuration;
+                            'chars_vocab.pkl'   : vocabulary definitions;
+                            'checkpoint'        : paths to model file(s) (created by tf).
+                                                  Note: this file contains absolute paths, be careful when moving files around;
+                            'model.ckpt-*'      : file(s) with model definition (created by tf)
+                             Model params must be the same between multiple runs (model, rnn_size, num_layers and seq_length).
+                        """)
+    # Model params
+    parser.add_argument('--model', type=str, default='lstm',
+                        help='lstm, rnn, gru, or nas')
     parser.add_argument('--rnn_size', type=int, default=128,
                         help='size of RNN hidden state')
     parser.add_argument('--num_layers', type=int, default=2,
                         help='number of layers in the RNN')
-    parser.add_argument('--model', type=str, default='lstm',
-                        help='rnn, gru, lstm, or nas')
-    parser.add_argument('--batch_size', type=int, default=50,
-                        help='minibatch size')
+    # Optimization
     parser.add_argument('--seq_length', type=int, default=50,
-                        help='RNN sequence length')
+                        help='RNN sequence length. Number of timesteps to unroll for.')
+    parser.add_argument('--batch_size', type=int, default=50,
+                        help="""minibatch size. Number of sequences propagated through the network in parallel.
+                                Pick batch-sizes to fully leverage the GPU (e.g. until the memory is filled up)
+                                commonly in the range 10-500.""")
     parser.add_argument('--num_epochs', type=int, default=50,
-                        help='number of epochs')
-    parser.add_argument('--save_every', type=int, default=1000,
-                        help='save frequency')
+                        help='number of epochs. Number of full passes through the training examples.')
     parser.add_argument('--grad_clip', type=float, default=5.,
                         help='clip gradients at this value')
     parser.add_argument('--learning_rate', type=float, default=0.002,
@@ -43,14 +58,6 @@ def main():
                         help='probability of keeping weights in the hidden layer')
     parser.add_argument('--input_keep_prob', type=float, default=1.0,
                         help='probability of keeping weights in the input layer')
-    parser.add_argument('--init_from', type=str, default=None,
-                        help="""continue training from saved model at this path. Path must contain files saved by previous training process:
-                            'config.pkl'        : configuration;
-                            'chars_vocab.pkl'   : vocabulary definitions;
-                            'checkpoint'        : paths to model file(s) (created by tf).
-                                                  Note: this file contains absolute paths, be careful when moving files around;
-                            'model.ckpt-*'      : file(s) with model definition (created by tf)
-                        """)
     args = parser.parse_args()
     train(args)
 


### PR DESCRIPTION
README: add useful tips gathered from an issue and stackoverflow

train.py: reorder and improve help message

 - ordered so that parameters of the model are separated from other non meaningfull configuration (paths, save freq...)
 - add some more information to help newcommers like me understand some parameters