### PR TITLE
Make sampling with a unicode prime work correctly

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -17,7 +17,7 @@ def main():
                         help='model directory to store checkpointed models')
     parser.add_argument('-n', type=int, default=500,
                         help='number of characters to sample')
-    parser.add_argument('--prime', type=text_type, default=u' ',
+    parser.add_argument('--prime', type=lambda s: unicode(s, 'utf8'), default=u' ',
                         help='prime text')
     parser.add_argument('--sample', type=int, default=1,
                         help='0 to use max at each timestep, 1 to sample at '


### PR DESCRIPTION
Running `sample.py` with a unicode prime fails with something in the
spirit of

```
sample.py: error: argument --prime: invalid unicode value: [...]
```

Using the approach suggested in
https://stackoverflow.com/a/22947334/596167 appears to fix things.