### PR TITLE
TensorFlow no longer supports Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
  - 3.6
  - 3.5
  - 3.4
- - 3.3
 
 # Use container-based infrastructure
 sudo: false


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/install/install_linux.md#installing-with-native-pip

* Python 2.7
* Python 3.4+

CPython 3.3 itself is no longer supported after this month:

https://en.wikipedia.org/wiki/CPython#Version_history