### PR TITLE
docs: fix simple typo, seperate -> separate

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -49,7 +49,7 @@ class TextLoader():
         self.tensor = np.load(tensor_file)
         self.num_batches = int(self.tensor.size / (self.batch_size *
                                                    self.seq_length))
-    # seperate the whole data into different batches.
+    # separate the whole data into different batches.
     def create_batches(self):
         self.num_batches = int(self.tensor.size / (self.batch_size *
                                                    self.seq_length))


### PR DESCRIPTION
There is a small typo in utils.py.

Should read `separate` rather than `seperate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md